### PR TITLE
Upgrade to latest `laminas/laminas-coding-standard` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "webmozart/assert": "^1.9"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "^2.1",
+        "laminas/laminas-coding-standard": "^2.1.1",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpspec/prophecy": "^1.12",
         "phpunit/phpunit": "^9.3",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,9 +17,5 @@
     <file>test</file>
 
     <!-- Include all rules from Laminas Coding Standard -->
-    <rule ref="LaminasCodingStandard">
-        <exclude name="WebimpressCodingStandard.Namespaces.UnusedUseStatement" />
-        <exclude name="WebimpressCodingStandard.Commenting.TagWithType.InvalidTypeFormat" />
-        <exclude name="WebimpressCodingStandard.Commenting.TagWithType.InvalidParamName" />
-    </rule>
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/test/UserRepository/PdoDatabaseFactoryTest.php
+++ b/test/UserRepository/PdoDatabaseFactoryTest.php
@@ -132,6 +132,7 @@ class PdoDatabaseFactoryTest extends TestCase
     }
 
     /**
+     * @param array<string,mixed> $pdoConfig
      * @dataProvider getPdoInvalidConfig
      */
     public function testInvokeWithInvalidConfig(array $pdoConfig): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes/no

### Description

Removes excluded rules from #8 
Gonna remove `repositories` for `laminas/laminas-coding-standard` when https://github.com/laminas/laminas-coding-standard/pull/44 got released.
