### PR TITLE
hotfix: psalm regression after updating to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#11](https://github.com/mezzio/mezzio-authentication/pull/11) Fixes an assertion error which was caused due to the implementation of Psalm in [#6](https://github.com/mezzio/mezzio-authentication/pull/6) and reported with [#10](https://github.com/mezzio/mezzio-authentication/issues/10). 
+  
+  Mezzio has support for multiple containers and some of those containers may return `ArrayObject` instead of an array.
 
 ## 1.2.0 - 2020-10-20
 

--- a/src/UserRepository/HtpasswdFactory.php
+++ b/src/UserRepository/HtpasswdFactory.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Authentication\UserRepository;
 
+use ArrayAccess;
 use Mezzio\Authentication\Exception;
 use Mezzio\Authentication\UserInterface;
 use Psr\Container\ContainerInterface;
@@ -24,9 +25,10 @@ class HtpasswdFactory
      */
     public function __invoke(ContainerInterface $container): Htpasswd
     {
-        $config = $container->get('config');
-        Assert::isMap($config);
+        /** @var ArrayAccess<array-key,mixed> $config */
+        $config     = $container->get('config');
         $authConfig = $config['authentication'] ?? [];
+        Assert::isMap($authConfig);
 
         $htpasswd = $authConfig['htpasswd'] ?? null;
         Assert::nullOrString($htpasswd);

--- a/test/UserRepository/HtpasswdFactoryTest/ConfigImplementingArrayAccess.php
+++ b/test/UserRepository/HtpasswdFactoryTest/ConfigImplementingArrayAccess.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Authentication\UserRepository\HtpasswdFactoryTest;
+
+use ArrayAccess;
+use OutOfBoundsException;
+
+use function array_key_exists;
+use function assert;
+use function is_string;
+
+/**
+ * @template-implements ArrayAccess<string,mixed>
+ */
+final class ConfigImplementingArrayAccess implements ArrayAccess
+{
+    /** @var array<array-key,mixed> */
+    private $data;
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @psalm-param array-key $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->data);
+    }
+
+    /**
+     * @psalm-param array-key $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        if (! $this->offsetExists($offset)) {
+            throw new OutOfBoundsException();
+        }
+
+        return $this->data[$offset];
+    }
+
+    /**
+     * @psalm-param array-key $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        assert(is_string($offset));
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * @psalm-param array-key $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

As mezzio supports multiple containers (which may only return objects), we have to cast the `ArrayObject` to an array to make a proper assertion.

Related container configurations:

https://github.com/jsoumelidis/zend-sf-di-config/blob/master/src/Config.php#L88
https://github.com/laminas/laminas-auradi-config/blob/2.1.x/src/Config.php#L66

Fixes #10 
Closes #10 
